### PR TITLE
Adding viewmodel for messages

### DIFF
--- a/webapp/lib/data_model.dart
+++ b/webapp/lib/data_model.dart
@@ -1,6 +1,7 @@
 /**
  * Represents the main data types used in Coda.
  */
+library coda.model;
 
 /// A collection of messages and code schemes.
 class Dataset {

--- a/webapp/lib/main_ui.dart
+++ b/webapp/lib/main_ui.dart
@@ -1,0 +1,59 @@
+/**
+ * The main UI of the application.
+ */
+library coda.ui;
+
+import 'dart:html';
+
+import 'data_model.dart';
+import 'view_model.dart';
+import 'temp_data.dart';
+
+void init() => new CodaUI();
+
+class CodaUI {
+  ButtonElement get saveButton => querySelector('#save-all-button');
+  TableElement get messageCodingTable => querySelector('#message-coding-table');
+
+  Dataset dataset;
+
+  CodaUI() {
+    // TODO: This is just for prototyping, the json dataset will come from a server
+    displayDataset(new Dataset.fromJson(jsonDataset));
+  }
+
+  displayDataset(Dataset dataset) {
+    clearMessageCodingTable(); // Clear up the table before loading the new dataset.
+    this.dataset = dataset;
+
+    messageCodingTable.append(createTableHeader(dataset));
+
+    TableSectionElement body = new Element.tag('tbody');
+    dataset.messages.forEach((message) {
+      MessageViewModel messageViewModel = new MessageViewModel(message, dataset);
+      body.append(messageViewModel.viewElement);
+    });
+    messageCodingTable.append(body);
+  }
+
+  createTableHeader(Dataset dataset) {
+    TableSectionElement header = new Element.tag('thead');
+    TableRowElement headerRow = header.addRow();
+    headerRow.addCell()
+      ..classes.add('message-id')
+      ..text = 'ID';
+    headerRow.addCell()
+      ..classes.add('message-text')
+      ..text = 'Message';
+    dataset.codeSchemes.forEach((codeScheme) {
+      headerRow.addCell()
+        ..classes.add('message-code')
+        ..text = codeScheme.schemeID;
+    });
+    return header;
+  }
+
+  void clearMessageCodingTable() {
+    // TODO: Implement clearing up the table
+  }
+}

--- a/webapp/lib/playground.dart
+++ b/webapp/lib/playground.dart
@@ -1,0 +1,201 @@
+/**
+ * The entry point of the application.
+ */
+library coda.playground;
+
+import 'dart:html';
+
+import 'data_model.dart';
+import 'view_model.dart';
+
+Playground get playground => _playground;
+
+Playground _playground;
+
+void init() {
+  _playground = new Playground();
+}
+
+class Playground {
+  ButtonElement get saveButton => querySelector('#save-all-button');
+  TableElement get messageCodingTable => querySelector('#message-coding-table');
+
+  Dataset dataset;
+
+  Playground() {
+    // TODO: This is just for prototyping, the jsondataset will come from a server
+    loadDataset(new Dataset.fromJson(jsonDataset));
+  }
+
+  loadDataset(Dataset dataset) {
+    clear(); // Clear up the playground before loading the new dataset.
+    this.dataset = dataset;
+
+    TableSectionElement header = new Element.tag('thead');
+    TableRowElement headerRow = header.addRow();
+    headerRow.addCell()
+      ..classes.add('message-id')
+      ..text = 'ID';
+    headerRow.addCell()
+      ..classes.add('message-text')
+      ..text = 'Message';
+    dataset.codeSchemes.forEach((codeScheme) {
+      headerRow.addCell()
+        ..classes.add('message-code')
+        ..text = codeScheme.schemeID;
+    });
+    messageCodingTable.append(header);
+
+    TableSectionElement body = new Element.tag('tbody');
+    dataset.messages.forEach((message) {
+      MessageViewModel messageViewModel = new MessageViewModel(message, dataset);
+      body.append(messageViewModel.viewElement);
+    });
+    messageCodingTable.append(body);
+  }
+
+  void clear() {
+    // TODO: Implement clearing up the table
+  }
+}
+
+Map jsonDataset = {
+  "Name": "Test",
+  "Documents": [
+    {
+      "MessageID": "msg 1",
+      "Text": "first message",
+      "CreationDateTimeUTC": "2018-09-23T14:12:00Z",
+      "Labels": [
+        {
+          "SchemeID": "scheme 1",
+          "DateTimeUTC": "2018-09-23T14:12:00Z",
+          "ValueID": "code 1",
+          "LabelOrigin": "info@example.com"
+        }
+      ]
+    },
+    {
+      "MessageID": "msg 2",
+      "Text": "second message",
+      "CreationDateTimeUTC": "2018-09-23T14:14:00Z",
+      "Labels": [
+        {
+          "SchemeID": "scheme 1",
+          "DateTimeUTC": "2018-09-23T14:12:00Z",
+          "ValueID": "code 1",
+          "LabelOrigin": "info@example.com"
+        },
+        {
+          "SchemeID": "scheme 2",
+          "DateTimeUTC": "2018-09-23T14:12:00Z",
+          "ValueID": "code 2",
+          "LabelOrigin": "info@example.com"
+        }
+      ]
+    },
+    {
+      "MessageID": "msg 3",
+      "Text": "third message",
+      "CreationDateTimeUTC": "2018-09-23T14:14:00Z",
+      "Labels": [
+        {
+          "SchemeID": "scheme 1",
+          "DateTimeUTC": "2018-09-23T14:12:00Z",
+          "ValueID": "code 1",
+          "LabelOrigin": "info@example.com"
+        },
+        {
+          "SchemeID": "scheme 2",
+          "DateTimeUTC": "2018-09-23T14:12:00Z",
+          "ValueID": "code 22",
+          "LabelOrigin": "info@example.com"
+        }
+      ]
+    },
+    {
+      "MessageID": "msg 4",
+      "Text": "fourth message",
+      "CreationDateTimeUTC": "2018-09-23T14:14:00Z",
+      "Labels": [
+        {
+          "SchemeID": "scheme 1",
+          "DateTimeUTC": "2018-09-23T14:12:00Z",
+          "ValueID": "code 2",
+          "LabelOrigin": "info@example.com"
+        },
+        {
+          "SchemeID": "scheme 1",
+          "DateTimeUTC": "2018-09-23T14:12:00Z",
+          "ValueID": "code 1",
+          "LabelOrigin": "info@example.com"
+        }
+      ]
+    },
+    {
+      "MessageID": "msg 5",
+      "Text": "fifth message",
+      "CreationDateTimeUTC": "2018-09-23T14:14:00Z",
+      "Labels": [
+        {
+          "SchemeID": "scheme 2",
+          "DateTimeUTC": "2018-09-23T14:12:00Z",
+          "ValueID": "code 2",
+          "LabelOrigin": "info@example.com"
+        },
+        {
+          "SchemeID": "scheme 1",
+          "DateTimeUTC": "2018-09-23T14:12:00Z",
+          "ValueID": "code 11",
+          "LabelOrigin": "info@example.com"
+        }
+      ]
+    },
+    {
+      "MessageID": "msg 6",
+      "Text": "sixth message",
+      "CreationDateTimeUTC": "2018-09-23T14:14:00Z",
+      "Labels": []
+    },
+    {
+      "MessageID": "msg 7",
+      "Text": "seventh message",
+      "CreationDateTimeUTC": "2018-09-23T14:14:00Z",
+      "Labels": []
+    }
+  ],
+  "CodeSchemes": [
+    {
+      "SchemeID": "scheme 1",
+      "Codes": [
+        {
+          "FriendlyName": "code 1",
+          "ValueID": "code 1",
+          "Colour": "#f46241",
+          "Shortcut": "1"
+        },
+        {
+          "FriendlyName": "code 2",
+          "ValueID": "code 2",
+          "Shortcut": "2"
+        }
+      ]
+    },
+    {
+      "SchemeID": "scheme 2",
+      "Codes": [
+        {
+          "FriendlyName": "code 1",
+          "ValueID": "code 1",
+          "Colour": "#f46241",
+          "Shortcut": "a"
+        },
+        {
+          "FriendlyName": "code 2",
+          "ValueID": "code 2",
+          "Shortcut": "b"
+        }
+      ]
+    }
+  ]
+};

--- a/webapp/lib/temp_data.dart
+++ b/webapp/lib/temp_data.dart
@@ -1,63 +1,8 @@
 /**
- * The entry point of the application.
+ * A file used to store any data used when prototyping.
  */
-library coda.playground;
 
-import 'dart:html';
-
-import 'data_model.dart';
-import 'view_model.dart';
-
-Playground get playground => _playground;
-
-Playground _playground;
-
-void init() {
-  _playground = new Playground();
-}
-
-class Playground {
-  ButtonElement get saveButton => querySelector('#save-all-button');
-  TableElement get messageCodingTable => querySelector('#message-coding-table');
-
-  Dataset dataset;
-
-  Playground() {
-    // TODO: This is just for prototyping, the jsondataset will come from a server
-    loadDataset(new Dataset.fromJson(jsonDataset));
-  }
-
-  loadDataset(Dataset dataset) {
-    clear(); // Clear up the playground before loading the new dataset.
-    this.dataset = dataset;
-
-    TableSectionElement header = new Element.tag('thead');
-    TableRowElement headerRow = header.addRow();
-    headerRow.addCell()
-      ..classes.add('message-id')
-      ..text = 'ID';
-    headerRow.addCell()
-      ..classes.add('message-text')
-      ..text = 'Message';
-    dataset.codeSchemes.forEach((codeScheme) {
-      headerRow.addCell()
-        ..classes.add('message-code')
-        ..text = codeScheme.schemeID;
-    });
-    messageCodingTable.append(header);
-
-    TableSectionElement body = new Element.tag('tbody');
-    dataset.messages.forEach((message) {
-      MessageViewModel messageViewModel = new MessageViewModel(message, dataset);
-      body.append(messageViewModel.viewElement);
-    });
-    messageCodingTable.append(body);
-  }
-
-  void clear() {
-    // TODO: Implement clearing up the table
-  }
-}
+library coda.temp.data;
 
 Map jsonDataset = {
   "Name": "Test",

--- a/webapp/lib/view_model.dart
+++ b/webapp/lib/view_model.dart
@@ -1,0 +1,128 @@
+/**
+ * Represents the ViewModel of the application, mediating between the data model and the HTML view.
+ */
+library coda.viewmodel;
+
+import 'dart:html';
+
+import 'data_model.dart';
+
+/// A ViewModel for a message, corresponding to a table row in the UI.
+class MessageViewModel {
+  Message message;
+  TableRowElement viewElement;
+  List<CodeSelector> codeSelectors = [];
+
+  MessageViewModel(this.message, Dataset dataset) {
+    viewElement = new TableRowElement();
+    viewElement.addCell()
+      ..classes.add('message-id')
+      ..text = message.messageID;
+    viewElement.addCell()
+      ..classes.add('message-text')
+      ..text = message.text;
+
+    dataset.codeSchemes.forEach((scheme) {
+      CodeSelector codeSelector = new CodeSelector(scheme);
+      codeSelectors.add(codeSelector);
+      // If the message is already labelled in this scheme, select that code.
+      var existingLabels = message.labels.where((label) => label.schemeID == scheme.schemeID);
+      if (existingLabels.isNotEmpty) {
+        Label label = existingLabels.last;
+        codeSelector.selectedOption = label.valueID;
+      }
+
+      codeSelector.addCheckboxListener((bool checked) {
+        // TODO: do something when the checkbox is checked/unchecked
+      });
+      codeSelector.addCodeSelectorListener((String valueID) {
+        // TODO: do something when a new code is selected
+      });
+      viewElement.addCell()
+        ..classes.add('message-code')
+        ..append(codeSelector.viewElement);
+    });
+  }
+}
+
+/// A typedef for the listener function to be called when a checkbox is changed.
+typedef void CheckboxChanged(bool checked);
+/// A typedef for the listener function to be called when the selected option in a selector is changed.
+typedef void SelectorChanged(String valueID);
+
+/// A dropdown code selector used to label a message within a coding scheme.
+class CodeSelector {
+  DivElement viewElement;
+  InputElement checkbox;
+  SelectElement codeSelector;
+  Element warning;
+
+  CodeSelector(Scheme scheme) {
+    viewElement = new DivElement();
+    viewElement.classes.add('input-group');
+    viewElement.attributes['scheme'] = scheme.schemeID;
+
+    checkbox = new InputElement(type: 'checkbox');
+    viewElement.append(checkbox);
+
+    codeSelector = new SelectElement();
+    codeSelector.classes.add('code-selector');
+    // An empty code used to unlabel the message
+    OptionElement option = new OptionElement();
+    option
+      ..attributes['schemeid'] = scheme.schemeID
+      ..attributes['codeid'] = 'unassign'
+      ..selected = true;
+    codeSelector.append(option);
+    scheme.codes.forEach((code) {
+      OptionElement option = new OptionElement();
+      option
+        ..attributes['schemeid'] = scheme.schemeID
+        ..attributes['valueid'] = code["valueID"]
+        ..text = code['name'];
+      codeSelector.append(option);
+    });
+    viewElement.append(codeSelector);
+
+    warning = new Element.tag('i');
+    warning
+      ..classes.add('fas')
+      ..classes.add('fa-exclamation')
+      ..classes.add('warning')
+      ..classes.add('hidden')
+      ..attributes['data-toggle'] = 'tooltip'
+      ..attributes['data-placement'] = 'bottom';
+    viewElement.append(warning);
+    // When an option from the list has been selected manually, the warning message should be hidden if it's not already.
+    addCodeSelectorListener((String valueID) => warning.classes.toggle('hidden', true));
+  }
+
+  addCheckboxListener(CheckboxChanged checkboxChanged) {
+    checkbox.onChange.listen((event) {
+      checkboxChanged(checkbox.checked);
+    });
+  }
+
+  addCodeSelectorListener(SelectorChanged selectorChanged) {
+    codeSelector.onChange.listen((event) {
+      selectorChanged(codeSelector.selectedOptions[0].attributes["valueid"]);
+    });
+  }
+
+  set checked(bool checked) => checkbox.checked = checked;
+  bool get checked => checkbox.checked;
+
+  set selectedOption(String valueID) {
+    OptionElement option = codeSelector.querySelector('option[valueid="$valueID"]');
+    // When the option set programmatically doesn't exist in the scheme, show the warning sign.
+    if (option == null) {
+      warning
+        ..classes.remove('hidden')
+        ..attributes['title'] = 'The message is pre-labelled with the code "$valueID" that doesn\'t exist in the scheme';
+    } else {
+      option.selected = true;
+    }
+  }
+
+  String get selectedOption => codeSelector.selectedOptions[0].attributes['valueid'];
+}

--- a/webapp/lib/view_model.dart
+++ b/webapp/lib/view_model.dart
@@ -7,6 +7,11 @@ import 'dart:html';
 
 import 'data_model.dart';
 
+/// A typedef for the listener function to be called when a checkbox is changed.
+typedef void CheckboxChanged(bool checked);
+/// A typedef for the listener function to be called when the selected option in a selector is changed.
+typedef void SelectorChanged(String valueID);
+
 /// A ViewModel for a message, corresponding to a table row in the UI.
 class MessageViewModel {
   Message message;
@@ -44,11 +49,6 @@ class MessageViewModel {
     });
   }
 }
-
-/// A typedef for the listener function to be called when a checkbox is changed.
-typedef void CheckboxChanged(bool checked);
-/// A typedef for the listener function to be called when the selected option in a selector is changed.
-typedef void SelectorChanged(String valueID);
 
 /// A dropdown code selector used to label a message within a coding scheme.
 class CodeSelector {

--- a/webapp/web/index.html
+++ b/webapp/web/index.html
@@ -72,78 +72,7 @@
     <!-- Main coding area -->
     <main>
       <table id="message-coding-table">
-        <thead>
-          <tr>
-            <th class="message-id">ID</th>
-            <th class="message-text">Message</th>
-            <th>Coding scheme 1</th>
-            <th>Coding scheme 2</th>
-          </tr>
-        </thead>
 
-        <tbody>
-          <tr>
-            <td class="message-id">1</td>
-            <td class="message-text">This is a message that someone has sent in.</td>
-            <td class="message-code">
-              <div class="input-group" scheme="1">
-                <input type="checkbox">
-                <select class="code-selector">
-                  <option codeid="1-01" selected>Code 1</option>
-                  <option codeid="1-02">Code 2</option>
-                  <option codeid="1-03">Code 3</option>
-                  <option codeid="1-04">Code 4</option>
-                  <option codeid="1-05">Code 5</option>
-                  </option>
-                </select>
-              </div>
-            </td>
-            <td class="message-code">
-              <div class="input-group" scheme="2">
-                <input type="checkbox">
-                <select class="code-selector">
-                  <option codeid="2-01" selected>Code 1</option>
-                  <option codeid="2-02">Code 2</option>
-                  <option codeid="2-03">Code 3</option>
-                  <option codeid="2-04">Code 4</option>
-                  <option codeid="2-05">Code 5</option>
-                  </option>
-                </select>
-              </div>
-            </td>
-          </tr>
-
-          <tr>
-              <td class="message-id">2</td>
-              <td class="message-text">This is a looooooooooooooooooooonger, much much looooooooooonger message that someone has sent in. Far to long actually to fit in a single row, so it'll have to wrap up on the other rows. Hopefully that should look quite good on the UI. </td>
-              <td class="message-code">
-                <div class="input-group" scheme="1">
-                  <input type="checkbox">
-                  <select class="code-selector">
-                    <option codeid="1-01" selected>Code 1</option>
-                    <option codeid="1-02">Code 2</option>
-                    <option codeid="1-03">Code 3</option>
-                    <option codeid="1-04">Code 4</option>
-                    <option codeid="1-05">Code 5</option>
-                    </option>
-                  </select>
-                </div>
-              </td>
-              <td class="message-code">
-                <div class="input-group" scheme="2">
-                  <input type="checkbox">
-                  <select class="code-selector">
-                    <option codeid="2-01" selected>Code 1</option>
-                    <option codeid="2-02">Code 2</option>
-                    <option codeid="2-03">Code 3</option>
-                    <option codeid="2-04">Code 4</option>
-                    <option codeid="2-05">Code 5</option>
-                    </option>
-                  </select>
-                </div>
-              </td>
-            </tr>
-        </tbody>
       </table>
     </main>
   </body>

--- a/webapp/web/main.css
+++ b/webapp/web/main.css
@@ -201,15 +201,14 @@ main tbody {
   vertical-align: top;
 }
 
-th {
-  text-align: left;
-}
-
-#message-coding-table th,
 #message-coding-table td {
   padding: 6px 12px;
   border: none;
   border-top: 1px solid #e7e7e7;
+  text-align: left;
+}
+#message-coding-table thead td {
+  font-weight: bold;
 }
 
 .message-id {
@@ -227,4 +226,14 @@ th {
 
 .input-group .code-selector {
   flex: 1;
+}
+
+.input-group .warning {
+  display: block;
+  margin: auto 0 auto 4px;
+  color: #ffaa00;
+}
+
+.input-group .warning.hidden {
+  visibility: hidden;
 }

--- a/webapp/web/main.dart
+++ b/webapp/web/main.dart
@@ -1,5 +1,5 @@
-import 'package:CodaV2/playground.dart' as playground;
+import 'package:CodaV2/main_ui.dart' as coda_ui;
 
 void main() {
-  playground.init();
+  coda_ui.init();
 }

--- a/webapp/web/main.dart
+++ b/webapp/web/main.dart
@@ -1,5 +1,5 @@
-import 'dart:html';
+import 'package:CodaV2/playground.dart' as playground;
 
 void main() {
-
+  playground.init();
 }


### PR DESCRIPTION
Messages can now be imported from a dataset, and I've added some scaffolding functionality for the code selectors.

Demo: https://www.cl.cam.ac.uk/~mcm79/codav2_demos/viewmodel-pr/

I'm planning to add tests for the UI, but wanted to send this first for feedback. I'll add the tests in the next PR.